### PR TITLE
Avoid modifying string literals

### DIFF
--- a/lib/otnetstring.rb
+++ b/lib/otnetstring.rb
@@ -28,7 +28,7 @@ module OTNetstring
     def parse(io, encoding = 'internal', fallback_encoding = nil)
       fallback_encoding = io.encoding if io.respond_to? :encoding
       io = StringIO.new(io) if io.respond_to? :to_str
-      length, byte = "", nil
+      length, byte = String.new, nil
 
       while byte.nil? || byte =~ /\d/
         length << byte if byte

--- a/lib/rb-fsevent/fsevent.rb
+++ b/lib/rb-fsevent/fsevent.rb
@@ -44,8 +44,8 @@ class FSEvent
     while @running && IO::select([@pipe], nil, nil, nil)
       # managing the IO ourselves allows us to be careful and never pass an
       # incomplete message to OTNetstring.parse()
-      message = ""
-      length = ""
+      message = String.new
+      length = String.new
       byte = nil
 
       reading_length = true


### PR DESCRIPTION
I was running in an environment where strings are frozen by default (using `RUBYOPT="--enable=frozen-string-literal"`) and was getting exceptions. 

Switching to `String.new` avoids this issue, without changing functionality. 

Before this PR, running tests using `RUBYOPT="--enable=frozen-string-literal rake` on this repo fails. After, it passes.