### PR TITLE
rescue Errno::EBADF when closing pipe

### DIFF
--- a/lib/rb-fsevent/fsevent.rb
+++ b/lib/rb-fsevent/fsevent.rb
@@ -89,7 +89,7 @@ class FSEvent
       Process.kill('KILL', @pipe.pid) if process_running?(@pipe.pid)
       @pipe.close
     end
-  rescue IOError
+  rescue IOError, Errno::EBADF
   ensure
     @running = false
   end


### PR DESCRIPTION
It's possible for the pipe to be invalid by the time we attempt to close it, causing it to raise `Errno::EBADF`:

```
E, [2022-02-02T15:56:26.134134 #2412] ERROR -- : Exception rescued in listen-worker_thread:
Errno::EBADF: Bad file descriptor
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/rb-fsevent-0.10.4/lib/rb-fsevent/fsevent.rb:90:in `close'
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/rb-fsevent-0.10.4/lib/rb-fsevent/fsevent.rb:90:in `stop'
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/rb-fsevent-0.10.4/lib/rb-fsevent/fsevent.rb:84:in `run'
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/listen-3.4.1/lib/listen/adapter/darwin.rb:49:in `block in _run'
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/listen-3.4.1/lib/listen/thread.rb:26:in `rescue_and_log'
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/listen-3.4.1/lib/listen/thread.rb:18:in `block in new'
--- Thread.new ---
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/listen-3.4.1/lib/listen/adapter/darwin.rb:49:in `_run'
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/listen-3.4.1/lib/listen/adapter/base.rb:79:in `block in start'
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/listen-3.4.1/lib/listen/thread.rb:26:in `rescue_and_log'
/Users/raph/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/listen-3.4.1/lib/listen/thread.rb:18:in `block in new'
```

I don't fully understand the circumstances which lead to this but it happens to me and others on my team regularly (Ruby 3.0.3, macOS Monterey + Big Sur, running a Rails 6.1 app with puma 5.2.2). Possibly similar to https://github.com/guard/rb-fsevent/pull/40

It does not appear to have any negative effects and since we're closing the pipe at this point anyway I don't think we can do much about it - the error output is distracting and doesn't seem actionable. Hence I suggest we rescue `Errno::EBADF` when closing the pipe just like we do for `IOError`.