### PR TITLE
Fix CodeClimate badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/thibaudgg/rb-fsevent)
+[![Code Climate Maintainability](https://codeclimate.com/github/guard/rb-fsevent.svg)](https://codeclimate.com/github/guard/rb-fsevent)
 [![endorse](https://api.coderwall.com/ttilley/endorsecount.png)](https://coderwall.com/ttilley)
 
 # rb-fsevent


### PR DESCRIPTION
This PR fixes a currently broken CodeClimate badge in README, since the badge URL has changed.